### PR TITLE
新規会員登録の編集

### DIFF
--- a/app/assets/javascript/sign_up.js
+++ b/app/assets/javascript/sign_up.js
@@ -1,0 +1,12 @@
+$(function(){
+  var password = '#password';
+  var passcheck = '#password-check';
+
+  $(passcheck).change(function(){
+    if ($(this).prop('checked')){
+      $(password).attr('type','text');
+    } else {
+      $(password).attr('type','password');
+    }
+  });
+});

--- a/app/assets/stylesheets/modules/_devise.scss
+++ b/app/assets/stylesheets/modules/_devise.scss
@@ -129,7 +129,7 @@ input[type=checkbox] {
 }
 
 .ProfileNew__form:first-of-type {
-  margin-right: 5px;
+  margin-right: 15px;
 }
 
 .year, .month, .day {

--- a/app/assets/stylesheets/modules/_devise.scss
+++ b/app/assets/stylesheets/modules/_devise.scss
@@ -99,6 +99,25 @@
   height: 220px;
 }
 
+.password-info-text {
+  margin: 8px 0 8px;
+  color: #888;
+  font-size: 14px;
+}
+
+input[type=checkbox] {
+  -ms-transform: scale(1.4, 1.4);
+  -webkit-transform: scale(1.4, 1.4);
+  transform: scale(1.4, 1.4);
+}
+
+.password-checkbox label {
+  padding: 0 0 0 8px;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+
 // ログインページ
 
 .SigninPage__main {

--- a/app/assets/stylesheets/modules/_devise.scss
+++ b/app/assets/stylesheets/modules/_devise.scss
@@ -132,7 +132,7 @@ input[type=checkbox] {
   margin-right: 5px;
 }
 
-.year,.month,.day{
+.year, .month, .day {
   height: 48px;
   padding: 0 16px;
   border-radius: 4px;

--- a/app/assets/stylesheets/modules/_devise.scss
+++ b/app/assets/stylesheets/modules/_devise.scss
@@ -46,7 +46,7 @@
 
 .FormField {
   &:not(:first-of-type) {
-    margin-top: 32px;
+    margin-top: 28px;
   }
   &__label{
     font-size: 14px;
@@ -95,10 +95,6 @@
   @include account-btn();
 }
 
-.AccountPage__footer {
-  height: 220px;
-}
-
 .password-info-text {
   margin: 8px 0 8px;
   color: #888;
@@ -115,6 +111,40 @@ input[type=checkbox] {
   padding: 0 0 0 8px;
   font-size: 14px;
   font-weight: 400;
+}
+
+.confirmation-title {
+  font-size: 16px;
+  color: #333;
+  font-weight: bold;
+}
+
+.confirmation-text {
+  padding: 8px 0 0;
+  font-size: 14px;
+  color: #333;
+}
+.ProfileNew {
+  display: flex;
+}
+
+.ProfileNew__form:first-of-type {
+  margin-right: 5px;
+}
+
+.year,.month,.day{
+  height: 48px;
+  padding: 0 16px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  width: 100%;
+}
+.birthday-line {
+  align-items: center;
 }
 
 
@@ -222,4 +252,38 @@ input[type=checkbox] {
 
 .Password-button {
   @include account-btn();
+}
+
+.AccountPage__footer {
+  &__top{
+    background-color: #f5f5f5;
+    height: 54px;
+    text-align: center;
+    vertical-align: baseline;
+  }
+  &__lists{
+    display: flex;
+    justify-content: center;
+    &__link{
+      text-decoration: none;
+      color: black;
+      margin: 16px 0px 0px 16px;
+      font-size: 12px;
+    }
+  }
+  &__image{
+    background-color: #f5f5f5;
+    height: 128px;
+    display: block;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    font-size: 36px;
+    text-decoration: none;
+    &__copyright{
+      font-size: 12px;
+      box-sizing: border-box;
+      color:black;
+    }
+  }
 }

--- a/app/assets/stylesheets/modules/_exhibition.scss
+++ b/app/assets/stylesheets/modules/_exhibition.scss
@@ -371,3 +371,5 @@
   background-color: rgb(34, 34, 34);
 }
 
+
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,6 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, profile_attributes: [:first_name, :last_name, :first_name_kana, :last_name_kana, :birthday]])
   end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  def new
+    @user = User.new
+    @profile = @user.build_profile
+  end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,10 +1,10 @@
 class Profile < ApplicationRecord
-  belongs_to: user
+  belongs_to :user
 
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :first_name_kana, presence: true
   validates :last_name_kana, presence: true
-  validates :birthday, presence: true
+  # validates :birthday, presence: true
 
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,10 @@
+class Profile < ApplicationRecord
+  belongs_to: user
+
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+  validates :first_name_kana, presence: true
+  validates :last_name_kana, presence: true
+  validates :birthday, presence: true
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,4 +17,6 @@ class User < ApplicationRecord
   has_many :saling_items, -> { where("buyer_id is NULL") }, foreign_key: "seller_id", class_name: "Item"
   has_many :sold_items, -> { where("buyer_id is not NULL") }, foreign_key: "seller_id", class_name: "Item"
 
+  has_one: profile
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,7 @@ class User < ApplicationRecord
   has_many :saling_items, -> { where("buyer_id is NULL") }, foreign_key: "seller_id", class_name: "Item"
   has_many :sold_items, -> { where("buyer_id is not NULL") }, foreign_key: "seller_id", class_name: "Item"
 
-  has_one: profile
+  has_one :profile
+  accepts_nested_attributes_for :profile
 
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -36,15 +36,15 @@
               = p.label :first_name, "お名前(全角)", class: "FormField__label"
               %span.form-require 必須
               .ProfileNew
-                = p.text_field :first_name, class: "FormField__input ProfileNew__form"
-                = p.text_field :last_name, class: "FormField__input ProfileNew__form"
+                = p.text_field :first_name, placeholder: "例)山田", class: "FormField__input ProfileNew__form"
+                = p.text_field :last_name, placeholder: "例)彩", class: "FormField__input ProfileNew__form"
 
               .FormField
                 = p.label :last_name, "お名前カナ(全角)", class: "FormField__label"
                 %span.form-require 必須
                 .ProfileNew
-                  = p.text_field :first_name_kana, class: "FormField__input ProfileNew__form"
-                  = p.text_field :last_name_kana, class: "FormField__input ProfileNew__form"
+                  = p.text_field :first_name_kana, placeholder: "例)ヤマダ", class: "FormField__input ProfileNew__form"
+                  = p.text_field :last_name_kana, placeholder: "例)アヤ", class: "FormField__input ProfileNew__form"
 
               .FormField
                 = p.label :birthday, "生年月日", class: "FormField__label"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -31,12 +31,49 @@
             %h3.confirmation-title 本人確認
             %p.confirmation-text 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
 
-          
+            
+
+          .FormField
+            = f.fields_for :profile do |p|
+              = p.label :first_name, class: "FormField__label"
+              %span.form-require 必須
+              .ProfileNew
+                = p.text_field :first_name, class: "FormField__input ProfileNew__form"
+                = p.text_field :last_name, class: "FormField__input ProfileNew__form"
+
+              .FormField
+                = p.label :last_name, class: "FormField__label"
+                %span.form-require 必須
+                .ProfileNew
+                  = p.text_field :first_name_kana, class: "FormField__input ProfileNew__form"
+                  = p.text_field :last_name_kana, class: "FormField__input ProfileNew__form"
+
+              .FormField
+                = p.label :birthday, class: "FormField__label"
+                %span.form-require 必須
+                .ProfileNew.birthday-line
+                  != sprintf(p.date_select(:birthday, prefix:'birthday',with_css_classes:'XXXXX', prompt:"--",use_month_numbers:true, start_year:Time.now.year, end_year:1900, date_separator:'%s', class: "FormField__input ProfileNew__form"),'年','月')+'日'
+                %p.password-info-text ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
+
+
+
           
           .actions
             = f.submit "登録する", class: 'Signup-button'        
-  
-  .AccountPage__footer
 
+    .AccountPage__footer
+      .AccountPage__footer__top
+        %ul.AccountPage__footer__lists
+          %li
+          = link_to 'プライバシー', '#', class: "AccountPage__footer__lists__link"
+          %li
+          = link_to 'FURIMA利用規約', '#', class: "AccountPage__footer__lists__link"
+          %li
+          = link_to '特定商取引に関する表記', '#', class: "AccountPage__footer__lists__link"
+      .AccountPage__footer__image
+        %h1.app-title
+          = link_to image_tag("logo/logo-white.png", class: "logo"), "#"
+        %p.AccountPage__footer__image__copyright
+          © FURIMA, Inc.
 
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -33,29 +33,26 @@
 
           .FormField
             = f.fields_for :profile do |p|
-              = p.label :first_name, class: "FormField__label"
+              = p.label :first_name, "お名前(全角)", class: "FormField__label"
               %span.form-require 必須
               .ProfileNew
                 = p.text_field :first_name, class: "FormField__input ProfileNew__form"
                 = p.text_field :last_name, class: "FormField__input ProfileNew__form"
 
               .FormField
-                = p.label :last_name, class: "FormField__label"
+                = p.label :last_name, "お名前カナ(全角)", class: "FormField__label"
                 %span.form-require 必須
                 .ProfileNew
                   = p.text_field :first_name_kana, class: "FormField__input ProfileNew__form"
                   = p.text_field :last_name_kana, class: "FormField__input ProfileNew__form"
 
               .FormField
-                = p.label :birthday, class: "FormField__label"
+                = p.label :birthday, "生年月日", class: "FormField__label"
                 %span.form-require 必須
                 .ProfileNew.birthday-line
                   != sprintf(p.date_select(:birthday, use_month_numbers: true,start_year: 1930, end_year: (Time.now.year - 10), default: Date.new(1989, 1, 1), prompt:"--", with_css_classes:'XXXXX', date_separator:'%s', class: "FormField__input ProfileNew__form"),'年','月')+'日'
                 %p.password-info-text ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
 
-
-
-          
           .actions
             = f.submit "登録する", class: 'Signup-button'        
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -31,8 +31,6 @@
             %h3.confirmation-title 本人確認
             %p.confirmation-text 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
 
-            
-
           .FormField
             = f.fields_for :profile do |p|
               = p.label :first_name, class: "FormField__label"
@@ -52,7 +50,7 @@
                 = p.label :birthday, class: "FormField__label"
                 %span.form-require 必須
                 .ProfileNew.birthday-line
-                  != sprintf(p.date_select(:birthday, prefix:'birthday',with_css_classes:'XXXXX', prompt:"--",use_month_numbers:true, start_year:Time.now.year, end_year:1900, date_separator:'%s', class: "FormField__input ProfileNew__form"),'年','月')+'日'
+                  != sprintf(p.date_select(:birthday, use_month_numbers: true,start_year: 1930, end_year: (Time.now.year - 10), default: Date.new(1989, 1, 1), prompt:"--", with_css_classes:'XXXXX', date_separator:'%s', class: "FormField__input ProfileNew__form"),'年','月')+'日'
                 %p.password-info-text ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
 
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -21,10 +21,20 @@
           .FormField
             = f.label :password, class: "FormField__label"
             %span.form-require 必須
-            = f.password_field :password, autocomplete: "off", placeholder: "8文字以上の半角英数字", class: "FormField__input"
+            = f.password_field :password, autocomplete: "off", placeholder: "8文字以上の半角英数字", class: "FormField__input", id:'password'
+            %p.password-info-text ※英字と数字の両方を含めて設定してください
+            .password-checkbox
+              %input#password-check{:type => "checkbox"}
+              %label{for: "js-passcheck"} パスワードを表示する
+
+          .FormField
+            %h3.confirmation-title 本人確認
+            %p.confirmation-text 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
+
+          
           
           .actions
-            = f.submit "登録する", class: 'Signup-button'
+            = f.submit "登録する", class: 'Signup-button'        
   
   .AccountPage__footer
 

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -35,4 +35,20 @@
             = f.submit "ログイン", class: 'Signin-button'
             = link_to new_user_password_path, class:"forgot-password" do
               パスワードをお忘れの方
-  .AccountPage__footer
+
+              
+    .AccountPage__footer
+      .AccountPage__footer__top
+        %ul.AccountPage__footer__lists
+          %li
+          = link_to 'プライバシー', '#', class: "AccountPage__footer__lists__link"
+          %li
+          = link_to 'FURIMA利用規約', '#', class: "AccountPage__footer__lists__link"
+          %li
+          = link_to '特定商取引に関する表記', '#', class: "AccountPage__footer__lists__link"
+      .AccountPage__footer__image
+        %h1.app-title
+          = link_to image_tag("logo/logo-white.png", class: "logo"), "#"
+        %p.AccountPage__footer__image__copyright
+          © FURIMA, Inc.
+

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,9 @@ module FleamarketNagoya79a
     config.load_defaults 6.0
 
     config.i18n.default_locale = :ja
+
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   
   root 'items#index'
-  devise_for :users
+  devise_for :users, controllers: { registrations: 'users/registrations' }
 
   resources :items, only: [:new, :create]
   resources :users, only: [:show]

--- a/db/migrate/20201108110646_create_profiles.rb
+++ b/db/migrate/20201108110646_create_profiles.rb
@@ -1,0 +1,15 @@
+class CreateProfiles < ActiveRecord::Migration[6.0]
+  def change
+    create_table :profiles do |t|
+      t.string :first_name, null: false
+      t.string :last_name, null: false
+      t.string :first_name_kana, null: false
+      t.string :last_name_kana, null: false
+      t.date :birthday, null: false
+      t.string :introduction
+      t.string :avatar
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_03_005516) do
+ActiveRecord::Schema.define(version: 2020_11_08_110646) do
 
   create_table "item_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "src", null: false
@@ -36,6 +36,20 @@ ActiveRecord::Schema.define(version: 2020_11_03_005516) do
     t.integer "buyer_id"
   end
 
+  create_table "profiles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.string "first_name_kana", null: false
+    t.string "last_name_kana", null: false
+    t.date "birthday", null: false
+    t.string "introduction"
+    t.string "avatar"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "email", default: "", null: false
@@ -50,4 +64,5 @@ ActiveRecord::Schema.define(version: 2020_11_03_005516) do
   end
 
   add_foreign_key "item_images", "items"
+  add_foreign_key "profiles", "users"
 end

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ProfileTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
新規会員登録でプロフィールの名前と生年月日が登録できるように実装した。残りのプロフィールの自己紹介文とアバター写真はマイページで編集できるようにする。

# Why
本人識別で必要だから。