### PR TITLE
新規登録画面の編集

### DIFF
--- a/app/assets/javascript/sign_up.js
+++ b/app/assets/javascript/sign_up.js
@@ -1,12 +1,9 @@
 $(function(){
-  var password = '#password';
-  var passcheck = '#password-check';
-
-  $(passcheck).change(function(){
+  $("#password-check").change(function(){
     if ($(this).prop('checked')){
-      $(password).attr('type','text');
+      $('#password').attr('type','text');
     } else {
-      $(password).attr('type','password');
+      $('#password').attr('type','password');
     }
   });
 });

--- a/app/assets/javascript/sign_up.js
+++ b/app/assets/javascript/sign_up.js
@@ -1,9 +1,9 @@
 $(function(){
   $("#password-check").change(function(){
     if ($(this).prop('checked')){
-      $('#password').attr('type','text');
+      $('.password').attr('type','text');
     } else {
-      $('#password').attr('type','password');
+      $('.password').attr('type','password');
     }
   });
 });

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,10 +1,13 @@
 class Profile < ApplicationRecord
   belongs_to :user
 
-  validates :first_name, presence: true
-  validates :last_name, presence: true
-  validates :first_name_kana, presence: true
-  validates :last_name_kana, presence: true
+  VALID_NAME_REGEX= /\A[一-龥ぁ-ん]/
+  VALID_NAME_KANA_REGEX= /\A[ァ-ヶー－]+\z/
+  
+  validates :first_name, presence: true, format: { with: VALID_NAME_REGEX }
+  validates :last_name, presence: true, format: { with: VALID_NAME_REGEX }
+  validates :first_name_kana, presence: true, format: { with: VALID_NAME_KANA_REGEX }
+  validates :last_name_kana, presence: true, format: { with: VALID_NAME_KANA_REGEX }
   validates :birthday, presence: true
 
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -20,13 +20,19 @@
             %span.form-require 必須
             = f.email_field :email, placeholder: "PC・携帯どちらでも可", class: "FormField__input"  
             - if resource.errors.include?(:email)
-              %p.AccountPage_error-message= resource.errors.full_messages_for(:email).first           
+              %p.AccountPage_error-message= resource.errors.full_messages_for(:email).first
           .FormField
             = f.label :password, class: "FormField__label"
             %span.form-require 必須
             = f.password_field :password, autocomplete: "off", placeholder: "8文字以上の半角英数字", class: "FormField__input", id:'password'
             - if resource.errors.include?(:password)
-              %p.AccountPage_error-message= resource.errors.full_messages_for(:password).first      
+              %p.AccountPage_error-message= resource.errors.full_messages_for(:password).first
+          .FormField
+            = f.label :password_confirmation, class: "FormField__label"
+            %span.form-require 必須
+            = f.password_field :password_confirmation, autocomplete: "off", placeholder: "8文字以上の半角英数字", class: "FormField__input", id:'password'
+            - if resource.errors.include?(:password_confirmation)
+              %p.AccountPage_error-message= resource.errors.full_messages_for(:password_confirmation).first
             %p.password-info-text ※英字と数字の両方を含めて設定してください
             .password-checkbox
               %input#password-check{:type => "checkbox"}

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -24,13 +24,13 @@
           .FormField
             = f.label :password, class: "FormField__label"
             %span.form-require 必須
-            = f.password_field :password, autocomplete: "off", placeholder: "8文字以上の半角英数字", class: "FormField__input", id:'password'
+            = f.password_field :password, autocomplete: "off", placeholder: "8文字以上の半角英数字", class: "FormField__input password"
             - if resource.errors.include?(:password)
               %p.AccountPage_error-message= resource.errors.full_messages_for(:password).first
           .FormField
             = f.label :password_confirmation, class: "FormField__label"
             %span.form-require 必須
-            = f.password_field :password_confirmation, autocomplete: "off", placeholder: "8文字以上の半角英数字", class: "FormField__input", id:'password'
+            = f.password_field :password_confirmation, autocomplete: "off", placeholder: "8文字以上の半角英数字", class: "FormField__input password"
             - if resource.errors.include?(:password_confirmation)
               %p.AccountPage_error-message= resource.errors.full_messages_for(:password_confirmation).first
             %p.password-info-text ※英字と数字の両方を含めて設定してください


### PR DESCRIPTION
# What
パスワード確認用のフォームを追加した。さらにパスワードをテキストで表示できるようにした。
名前と名前のふり仮名に全角のバリデーションをかけた。
これで新規登録とログイン機能は完成。

# Why
必要であったため。